### PR TITLE
Fix unicode chars causing errors

### DIFF
--- a/simple_search/models.py
+++ b/simple_search/models.py
@@ -150,7 +150,11 @@ def unindex_instance(instance):
 
 
 def parse_terms(search_string):
-    return shlex.split(smart_str(search_string.lower()))
+    terms = shlex.split(smart_str(search_string.lower()))
+
+    # The split requires the unicode string to be encoded to a bytestring, but
+    # we need the terms to be decoded back to utf-8 for use in the datastore queries.
+    return [smart_unicode(term) for term in terms]
 
 def search(model_class, search_string, per_page=50, current_page=1, total_pages=10, **filters):
     terms = parse_terms(search_string)

--- a/simple_search/tests.py
+++ b/simple_search/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 This file demonstrates writing tests using the unittest module. These will pass
 when you run "manage.py test".
@@ -156,3 +157,14 @@ class SearchTests(TestCase):
         goc = GlobalOccuranceCount.objects.get(pk="banana")
         self.assertEqual(1, goc.count)
         self.assertEqual(2, Index.objects.count())
+
+    def test_non_ascii_characters_in_search_string(self):
+        """
+        Validates that using a search string with characters outside the ASCII
+        set works as expected.
+        """
+        instance1 = SampleModel.objects.create(field1="Banana", field2=u"čherry")
+        index_instance(instance1, ["field1", "field2"], defer_index=False)
+        self.assertItemsEqual([instance1], search(SampleModel, u"čherry"))
+
+


### PR DESCRIPTION
Previously when searching using special characters, it was causing 500s of being unable to decode the character in the string (when being used to lookup items in the datastore queries). This looks like it was because when the search term parser splits the search terms it requires the string to be encoded as a bytestring, but then this isn't getting decoded back to utf-8, so added a line to do this and an accompanying test.